### PR TITLE
Add Config for Test Coverage

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -29,4 +29,12 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-gradle
     - name: Build with Gradle
-      run: ./gradlew build
+      run: ./gradlew build -x test
+
+    - name: Test with Gradle
+      run: ./gradlew test
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v1
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        file: ./build/reports/jacoco/test/jacocoTestReport.xml

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # slack_clone_backend
+[![CI with Gradle](https://github.com/SCCPJT/instagram_clone_backend/actions/workflows/gradle.yml/badge.svg?branch=develop)](https://github.com/SCCPJT/instagram_clone_backend/actions/workflows/gradle.yml) [![codecov](https://codecov.io/gh/SCCPJT/instagram_clone_backend/branch/develop/graph/badge.svg?token=9J7U6ZHVXJ)](https://codecov.io/gh/SCCPJT/instagram_clone_backend)
+
 
 슬랙 클론 코딩 Back-end
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-# slack_clone_backend
-[![CI with Gradle](https://github.com/SCCPJT/instagram_clone_backend/actions/workflows/gradle.yml/badge.svg?branch=develop)](https://github.com/SCCPJT/instagram_clone_backend/actions/workflows/gradle.yml) [![codecov](https://codecov.io/gh/SCCPJT/instagram_clone_backend/branch/develop/graph/badge.svg?token=9J7U6ZHVXJ)](https://codecov.io/gh/SCCPJT/instagram_clone_backend)
+# slack_clone_backend [![CI with Gradle](https://github.com/SCCPJT/instagram_clone_backend/actions/workflows/gradle.yml/badge.svg?branch=develop)](https://github.com/SCCPJT/instagram_clone_backend/actions/workflows/gradle.yml) [![codecov](https://codecov.io/gh/SCCPJT/instagram_clone_backend/branch/develop/graph/badge.svg?token=9J7U6ZHVXJ)](https://codecov.io/gh/SCCPJT/instagram_clone_backend)
 
 
 슬랙 클론 코딩 Back-end

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
 	id 'org.springframework.boot' version '2.4.3'
 	id 'io.spring.dependency-management' version '1.0.11.RELEASE'
 	id 'java'
+	id 'jacoco'
 }
 
 group = 'our.yurivongella'
@@ -11,6 +12,17 @@ sourceCompatibility = '1.8'
 configurations {
 	compileOnly {
 		extendsFrom annotationProcessor
+	}
+}
+
+jacoco{
+	toolVersion = "0.8.5"
+}
+
+jacocoTestReport{
+	reports{
+		xml.enabled = true // for Codecov
+		html.enabled = true
 	}
 }
 


### PR DESCRIPTION
## Description

coverage 측정 도구 jacoco
coverage 관리 도구 codecov 추가

## Changes

- plugin 추가, gradle.yml 수정

## 참고 문서

- https://github.com/marketplace/actions/codecov
- https://github.com/jacoco/jacoco

## 참고 블로그

- https://dublin-java.tistory.com/65

## Coverage check

- https://app.codecov.io/gh/SCCPJT/instagram_clone_backend/
