### PR TITLE
chore : Add Cascade Option

### DIFF
--- a/src/main/java/our/yurivongella/instagramclone/domain/comment/Comment.java
+++ b/src/main/java/our/yurivongella/instagramclone/domain/comment/Comment.java
@@ -3,6 +3,7 @@ package our.yurivongella.instagramclone.domain.comment;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -41,7 +42,7 @@ public class Comment extends BaseEntity {
     @JoinColumn(name = "post_id")
     private Post post;
 
-    @OneToMany(mappedBy = "comment")
+    @OneToMany(mappedBy = "comment", cascade = CascadeType.REMOVE)
     private List<CommentLike> commentLikes = new ArrayList<>();
 
 }

--- a/src/main/java/our/yurivongella/instagramclone/domain/comment/CommentLike.java
+++ b/src/main/java/our/yurivongella/instagramclone/domain/comment/CommentLike.java
@@ -22,7 +22,7 @@ import our.yurivongella.instagramclone.domain.member.Member;
 public class CommentLike extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "comment_link_id")
+    @Column(name = "comment_like_id")
     private Long id;
 
     @JoinColumn(name = "comment_id")

--- a/src/main/java/our/yurivongella/instagramclone/domain/comment/CommentLikeRepository.java
+++ b/src/main/java/our/yurivongella/instagramclone/domain/comment/CommentLikeRepository.java
@@ -2,5 +2,5 @@ package our.yurivongella.instagramclone.domain.comment;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ComentLikeRepository extends JpaRepository<CommentLike, Long> {
+public interface CommentLikeRepository extends JpaRepository<CommentLike, Long> {
 }

--- a/src/main/java/our/yurivongella/instagramclone/domain/member/Member.java
+++ b/src/main/java/our/yurivongella/instagramclone/domain/member/Member.java
@@ -24,7 +24,7 @@ import our.yurivongella.instagramclone.domain.post.PostLike;
 @Getter
 @Entity
 @NoArgsConstructor
-@Table
+@Table(name = "member")
 public class Member extends BaseEntity {
 
     @Id

--- a/src/main/java/our/yurivongella/instagramclone/domain/post/Post.java
+++ b/src/main/java/our/yurivongella/instagramclone/domain/post/Post.java
@@ -3,6 +3,7 @@ package our.yurivongella.instagramclone.domain.post;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -40,16 +41,14 @@ public class Post extends BaseEntity {
     @OneToMany(mappedBy = "post")
     List<PictureURL> pictureURLs = new ArrayList<>();
 
-    @OneToMany(mappedBy = "post")
+    @OneToMany(mappedBy = "post", cascade = CascadeType.REMOVE)
     List<PostLike> postLikes = new ArrayList<>();
 
-    @OneToMany(mappedBy = "post")
+    @OneToMany(mappedBy = "post", cascade = CascadeType.REMOVE)
     List<Comment> comments = new ArrayList<>();
 
     @Builder
-    public Post(Member member, String content, List<PictureURL> pictureURLs) {
-        this.member = member;
+    public Post(String content) {
         this.content = content;
-        this.pictureURLs = pictureURLs;
     }
 }


### PR DESCRIPTION
## Description

Post 삭제시, 같이 있던 Post 좋아요, 댓글, 댓글 좋아요 모두 사라지도록 변경.
즉, Post 하나만 삭제해도 위와 같이 얽힌 데이터(PostLike, Comment, CommentLike)가 모두 삭제가 됨.

Member 삭제시 사라지는 정보들에 대해서는 정책 협의가 필요할 것 같아서, 그대로 둠.

Domain에서 CommentLike Table 오타 수정

## Changes

- Cascade Delete Option 추가