### PR TITLE
feat : Add configuration (profiles)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 
 group = 'our.yurivongella'
 version = '0.0.1-SNAPSHOT'
-sourceCompatibility = '1.8'
+sourceCompatibility = '11'
 
 configurations {
     compileOnly {
@@ -46,7 +46,6 @@ jacocoTestCoverageVerification {
 
 
 repositories {
-	mavenCentral()
 	jcenter()
 }
 
@@ -57,8 +56,9 @@ dependencies {
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     annotationProcessor 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
+	runtimeOnly 'mysql:mysql-connector-java'
 
-    implementation 'io.springfox:springfox-swagger2:2.6.1'
+	implementation 'io.springfox:springfox-swagger2:2.6.1'
     implementation 'io.springfox:springfox-swagger-ui:2.6.1'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,4 +1,14 @@
+logging:
+  level:
+    our.yurivongella.instagramclone: debug
+
+---
+
 spring:
+  config:
+    activate:
+      on-profile: h2
+
   h2:
     console:
       enabled: true
@@ -18,7 +28,25 @@ spring:
         format_sql: true
         show_sql: true
 
+---
 
-logging:
-  level:
-    our.yurivongella.instagramclone: debug
+spring:
+  config:
+    activate:
+      on-profile: mysql
+
+  datasource:
+    hikari:
+      jdbc-url: jdbc:mysql://localhost:3306/instagram?serverTimezone=UTC
+      username: yuri
+      password: 1234
+      driver-class-name: com.mysql.cj.jdbc.Driver
+
+  jpa:
+    database-platform: org.hibernate.dialect.MySQL8Dialect
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        format_sql: true
+        show_sql: true

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -18,7 +18,6 @@ spring:
         format_sql: true
         show_sql: true
 
-
 logging:
   level:
     our.yurivongella.instagramclone: debug


### PR DESCRIPTION
## Description

Fixes #21 

## Changes

- application.yml 환경 profile 설정 ( h2, mysql )

## Just Follow!

![image](https://user-images.githubusercontent.com/37108728/109441964-29c04f80-7a7a-11eb-85e0-1d06f1084c2b.png)
![image](https://user-images.githubusercontent.com/37108728/109442005-4492c400-7a7a-11eb-9194-d9d3dcd897e4.png)


[profile을 h2로 실행했을 때]
![image](https://user-images.githubusercontent.com/37108728/109442087-84f24200-7a7a-11eb-840b-0fff186e3676.png)

[profile을 mysql로 실행했을 때]
![image](https://user-images.githubusercontent.com/37108728/109442131-a7845b00-7a7a-11eb-9dfe-2e09f79de2f9.png)


물론, local mysql의 scheme로 `instagram`은 개발자들이 만들어줘야 합니다!.
